### PR TITLE
Added createGlobalStyle to the list of default tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
           "default": [
             "styled",
             "css",
-            "sty"
+            "sty",
+            "createGlobalStyle"
           ]
         },
         "styled-components.validate": {


### PR DESCRIPTION
Steps to verify new functionality:
1. Create the following file.
```typescript
import { createGlobalStyle } from 'styled-components';

export default createGlobalStyle``;
```

2. Verify that CSS intellisense is working inside of the template string.